### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,14 +3,25 @@ GO_FLAGS =  -x
 NT_BUILD_FLAGS = -a -ldflags '-s -w' -buildmode=exe
 
 run_tests:
-	@ go clean -testcache
-	@ go test -v ./...
+        @ go clean -testcache
+        @ go test -v ./...
 
 buildDebug:
-	@ go build -o insider
+        @ go build -o insider
 
-build:
-	@ GOOS=linux GOARCH=386 go build ${BUILD_FLAGS} ${GO_FLAGS} -o insider
-
-buildWindows:
-	@ GOOS=windows GOARCH=386 go build ${NT_BUILD_FLAGS} ${GO_FLAGS} -o insider.exe
+macos:
+        @ GOOS=darwin GOARCH=amd64 CGO_ENABLED=1 go build ${BUILD_FLAGS} ${GO_FLAGS} -o insider-macos-amd64
+linux64:
+        @ GOOS=linux GOARCH=amd64 go build ${BUILD_FLAGS} ${GO_FLAGS} -o insider-linux-amd64
+linux32:
+        @ GOOS=linux GOARCH=386 go build ${BUILD_FLAGS} ${GO_FLAGS} -o insider-linux-x86
+win32:
+        @ GOOS=windows GOARCH=386 go build ${NT_BUILD_FLAGS} ${GO_FLAGS} -o insider-x86.exe
+win64:
+        @ GOOS=windows GOARCH=amd64 go build ${NT_BUILD_FLAGS} ${GO_FLAGS} -o insider-x64.exe
+all:
+        @ GOOS=linux GOARCH=amd64 go build ${BUILD_FLAGS} ${GO_FLAGS} -o insider-linux-amd64
+        @ GOOS=linux GOARCH=386 go build ${BUILD_FLAGS} ${GO_FLAGS} -o insider-linux-x86
+        @ GOOS=windows GOARCH=386 go build ${NT_BUILD_FLAGS} ${GO_FLAGS} -o insider-x86.exe
+        @ GOOS=windows GOARCH=amd64 go build ${NT_BUILD_FLAGS} ${GO_FLAGS} -o insider-x64.exe
+        @ GOOS=darwin GOARCH=amd64 CGO_ENABLED=1 go build ${BUILD_FLAGS} ${GO_FLAGS} -o insider-macos-amd64


### PR DESCRIPTION
Update Makefile adding linux32/64, macOS and win32/64

### What was a problem?

make does not build for macos, linux64 and win32

### How this PR fixes the problem?

Makefile changed adding various OS

### Check lists (check `x` in `[ ]` of list items)

- [ ] Test passed (soon)
- [ ] Coding style (indentation, etc)

### Additional Comments (if any)

{Please write here}