### PR TITLE
removing disclaimer about license on CLI output

### DIFF
--- a/models/reports/insider.go
+++ b/models/reports/insider.go
@@ -279,13 +279,6 @@ func ResumeReport(r newreport) {
 	log.Println("You are using the Insider open source version. If you like the product and want more features,")
 	log.Println("visit http://insidersec.io and get to know our enterprise version.")
 	log.Println("If you are a developer, then you can contribute to the improvement of the software while using an open source version")
-	log.Println("-----------------------------------------------------------------------------------------------------------------------")
-	log.Println("This Project are free software except otherwise stated. You can redistribute it and/or modify it under the terms of the ")
-	log.Println("GNU General Public License as published by the Free Software Foundation. ")
-	log.Println("This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY")
-	log.Println("without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. ")
-	log.Println("See the GNU General Public License for more details.")
-	log.Println("-----------------------------------------------------------------------------------------------------------------------")
 }
 
 func ConsoleReport(r newreport) {


### PR DESCRIPTION
Hi,

I removed a disclaimer that is revealed in the tool's output, I believe that this message only makes sense to be kept within the reports and here on Github itself.

Thx