### PR TITLE
Fix load files in directory with *git* prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
       <img src="https://img.shields.io/badge/license-LGPL-blue.svg">
     </a>
     <a href="https://github.com/insidersec/insider/releases">
-      <img src="https://img.shields.io/badge/version-2.0.0-blue.svg">
+      <img src="https://img.shields.io/badge/version-2.0.4-blue.svg">
     </a>
   </p>
 </p>

--- a/visitor/reader.go
+++ b/visitor/reader.go
@@ -24,7 +24,7 @@ var csharpExtensionFilter *regexp.Regexp
 var androidExtensionFilter *regexp.Regexp
 
 func init() {
-	ExtensionFilter = regexp.MustCompile(`(\w*\.[ot]tf)|(\w*\.bat)|(\w*\.sh)|(\w*\.png)|(\w*\.jpg)|(\w*\.jpeg)|(\w*\.pdf)|(\w*\.md)|(\w*\.markdown)|(\w*\.svg)|(\w*\.woff2)|(\w*\.woff)|(\w*\.ico)|(\w*LICENSE)|(\w*\.txt)|(\w*\.eot)|(\w*\.git)`)
+	ExtensionFilter = regexp.MustCompile(`(\w*\.[ot]tf)|(\w*\.bat)|(\w*\.sh)|(\w*\.png)|(\w*\.jpg)|(\w*\.jpeg)|(\w*\.pdf)|(\w*\.md)|(\w*\.markdown)|(\w*\.svg)|(\w*\.woff2)|(\w*\.woff)|(\w*\.ico)|(\w*LICENSE)|(\w*\.txt)|(\w*\.eot)|(\w*\.git\W)|(\w*\.gitignore)`)
 
 	androidExtensionFilter =
 		regexp.MustCompile(`(\s*gradle\/.+\.jar)|(\w+\/android\/\w+)|(.+\.aar)|(.+\.cpp)|(.+\.h)|(.+\.mk)|(.+\.c)|(.+\.dex)|(.+\.apk)`)
@@ -35,7 +35,7 @@ func init() {
 
 	csharpExtensionFilter = regexp.MustCompile(`(.+\.css)|(.+\.map)|(.+\.js)|(.+\.exe)|(.+\.dll)|(.+\.p12)|(.+\.xml)|(.+\.svcmap)|(.+\.svcinfo)|(.+\.disco)|(.+\.cache)`)
 
-	jsExtensionFilter = regexp.MustCompile(`(.+\.js)|(.+\.jsx)|(.+\.ts)|(.+\.tsx)|`)
+	jsExtensionFilter = regexp.MustCompile(`(.+\.js)|(.+\.jsx)|(.+\.ts)|(.+\.tsx)`)
 }
 
 func androidManifestFilter(filename string) bool {


### PR DESCRIPTION
### What was a problem?
Insider don't load files in repository if your name contains \*git\*, like username.github.io

### How this PR fixes the problem?

This PR change the regex to ignore .git/ and allow \*\*.git\*\* folders, but I'think that we should improvement the mechanism of load files that need to be analyzed. 

This PR also includes regex changes to include javascript files in the validation (other types of files were being included in the validation)

