### PR TITLE
adding Dockerfile for Insider

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# USAGE EXAMPLES
+# docker build -t insider .
+# docker run -ti --rm insider -tech android -target $pwd
+# docker run -ti --rm insider -tech javascript -target <myprojectfolder>
+# docker run -ti --rm insider -tech=android -target=<myandroidfolder>
+# docker run -ti --rm insider -tech android -target <myfolder> -no-html
+
+FROM  alpine
+
+    ENV VERSION 2.0.5
+    RUN wget -q -O - "https://github.com/insidersec/insider/releases/download/${VERSION}/insider_${VERSION}_linux_x86_64.tar.gz" | tar xz
+    RUN chmod +x insider
+    ENTRYPOINT [ "./insider" ]
+    CMD [ "--help" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,15 @@
 # USAGE EXAMPLES
 # docker build -t insider .
-# docker run -ti --rm insider -tech android -target $pwd
-# docker run -ti --rm insider -tech javascript -target <myprojectfolder>
-# docker run -ti --rm insider -tech=android -target=<myandroidfolder>
-# docker run -ti --rm insider -tech android -target <myfolder> -no-html
+# docker run -ti --rm -v $(pwd)/project:/opt/insider insider -tech android -target /opt/insider
+# docker run -ti --rm -v $(pwd)/project:/opt/insider insider -tech javascript -target </opt/insider>
+# docker run -ti --rm -v $(pwd)/project:/opt/insider insider -tech=android -target=</opt/insider>
+# docker run -ti --rm -v $(pwd)/project:/opt/insider insider -tech android -target </opt/insider> -no-html
 
-FROM  alpine
-
-    ENV VERSION 2.0.5
-    RUN wget -q -O - "https://github.com/insidersec/insider/releases/download/${VERSION}/insider_${VERSION}_linux_x86_64.tar.gz" | tar xz
-    RUN chmod +x insider
-    ENTRYPOINT [ "./insider" ]
-    CMD [ "--help" ]
+FROM alpine
+ENV VERSION 2.0.5
+RUN mkdir -p /opt/insider
+WORKDIR /opt/insider
+RUN wget -q -O - "https://github.com/insidersec/insider/releases/download/${VERSION}/insider_${VERSION}_linux_x86_64.tar.gz" | tar xz
+RUN chmod +x insider
+ENTRYPOINT [ "./insider" ]
+CMD [ "--help" ]


### PR DESCRIPTION
### What was a problem?
Many people used to Docker wanted to test your solution as a container

### How this PR fixes the problem?
this Dockerfile makes it possible to build and run Insider locally

### Check lists (check `x` in `[ ]` of list items)

- [x] Test passed (soon)
- [x] Coding style (indentation, etc)

### Additional Comments (if any)

still missing a variable to save the json reports somewhere other than root dir, in order to mount as a volume saving the reports locally before container dies.