### PR TITLE
Fix docker invocation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ $ ./insider --tech javascript  --target <projectfolder>
 You can also run `insider` in a container. You only need to mount the target into a volume:
 
 ```bash
-$ docker run --rm -v $(pwd):/target-project insidersec/insider -tech <tech> -target /target-project
+$ docker run -v $(pwd):/target-project insidersec/insider -tech <tech> -target /target-project
 
 ```
 


### PR DESCRIPTION
### What was a problem?

The docker version should not be run with the `--rm`, as this would delete the report right away.

### How this PR fixes the problem?

Remove the option from the README

### Check lists (check `x` in `[ ]` of list items)

- [ ] ~~Test passed (soon)~~
- [ ] ~~Coding style (indentation, etc)~~

### Additional Comments (if any)

Optimally, there should be solution to store the report in a different folder.